### PR TITLE
Update versions and make the results reproducible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/target/
+target/
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -204,3 +204,21 @@ We will keep working to improve the performance of our parsers, and will update 
 Head on to the [uniVocity-parsers github page](http://github.com/uniVocity/univocity-parsers/) to get access to its source code and documentation. Contributions are welcome.
 
 #### Commercial support is available for your peace of mind. [Click here to learn more.](http://www.univocity.com/products/parsers-support)
+
+## Building and Running
+
+Prerequisites: Git, wget, gunzip, Apache Maven, and Java 1.6+.
+The appropriate CSV parser library version will be chosen depending on your JDK version (i.e. 1.6, 1.7, or 1.8).
+
+If you wish to reproduce our performance results:
+
+```bash
+$ git clone https://github.com/uniVocity/csv-parsers-comparison.git
+$ cd csv-parsers-comparison
+$ wget http://www.maxmind.com/download/worldcities/worldcitiespop.txt.gz
+$ gunzip worldcitiespop.txt.gz
+$ mvn clean package
+$ jar target/csv-parsers-comparison-1.0-uber.jar .
+```
+
+NOTE: the `.` at the end of the last command, this tells Java the folder containing the `worldcitiespop.txt`. You can alternatively specify a path to any folder that contains a `worldcitiespop.txt` file.

--- a/pom.xml
+++ b/pom.xml
@@ -87,31 +87,31 @@
 		<dependency>
 			<groupId>com.univocity</groupId>
 			<artifactId>univocity-parsers</artifactId>
-			<version>1.3.0</version>
+			<version>2.5.6</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.csveed</groupId>
 			<artifactId>csveed</artifactId>
-			<version>0.4.0</version>
+			<version>0.5.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.4</version>
+			<version>1.4</version>		<!-- 1.5+ requires Java 7 -->
 		</dependency>
 
 		<dependency>
 			<groupId>net.sf.flatpack</groupId>
 			<artifactId>flatpack</artifactId>
-			<version>3.4.2</version>
+			<version>3.4.2</version>	<!-- 4.x+ requires Java 8 -->
 		</dependency>
 
 		<dependency>
 			<groupId>net.sf.supercsv</groupId>
 			<artifactId>super-csv</artifactId>
-			<version>2.2.0</version>
+			<version>2.4.0</version>
 		</dependency>
 
 		<dependency>
@@ -130,13 +130,13 @@
 		<dependency>
 			<groupId>com.espertech</groupId>
 			<artifactId>esperio-csv</artifactId>
-			<version>4.11.0</version>
+			<version>5.5.0</version>	<!-- 6.x+ requires Java 8 -->
 		</dependency>
 
 		<dependency>
 			<groupId>br.com.objectos</groupId>
 			<artifactId>way-io</artifactId>
-			<version>1.6.0</version>
+			<version>1.25.0</version>	<!-- 2.x+ requires Java 7 -->
 		</dependency>
 
 		<dependency>
@@ -154,13 +154,13 @@
 		<dependency>
 			<groupId>net.quux00.simplecsv</groupId>
 			<artifactId>simplecsv</artifactId>
-			<version>2.0</version>
+			<version>2.1</version>
 		</dependency>
 
 		<dependency>
-			<groupId>jdom</groupId>
+			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
-			<version>1.0</version>
+			<version>1.1</version>
 		</dependency>
 
 		<dependency>
@@ -172,18 +172,18 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>
-			<version>2.4.2</version>
+			<version>2.6.7</version>	<!-- 2.7+ requires Java 7 -->
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.4.2</version>
+			<version>2.6.7</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.arnaudroger</groupId>
-			<artifactId>simpleFlatMapper</artifactId>
-			<version>1.0.0rc2</version>
+			<groupId>org.simpleflatmapper</groupId>
+			<artifactId>sfm-csv</artifactId>
+			<version>3.13.2</version>
 			<classifier>jdk16</classifier>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,42 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<mainClass>com.univocity.articles.csvcomparison.PerformanceComparison</mainClass>
+						</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+							<resource>META-INF/LICENSE-2.0.html</resource>
+							<file>LICENSE-2.0.html</file>
+						</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+							<resource>META-INF/README.md</resource>
+							<file>README.md</file>
+						</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+							<resource>correctness.csv</resource>
+							<file>correctness.csv</file>
+						</transformer>
+					</transformers>
+					<shadedArtifactAttached>true</shadedArtifactAttached>
+					<shadedClassifierName>uber</shadedClassifierName>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -193,4 +193,120 @@
 			<version>1.07.00</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+
+		<profile>
+			<id>jdk1.7</id>
+			<activation>
+				<jdk>1.7</jdk>
+			</activation>
+			<dependencies>
+
+				<dependency>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-csv</artifactId>
+					<version>1.5</version>
+				</dependency>
+
+				<dependency>
+					<groupId>br.com.objectos</groupId>
+					<artifactId>way-io</artifactId>
+					<version>2.1.0</version>
+				</dependency>
+
+				<dependency>
+					<groupId>com.fasterxml.jackson.dataformat</groupId>
+					<artifactId>jackson-dataformat-csv</artifactId>
+					<version>2.7.9</version>
+				</dependency>
+				<dependency>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+					<version>2.7.9</version>
+				</dependency>
+
+			</dependencies>
+		</profile>
+
+		<profile>
+			<id>jdk1.8</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<dependencies>
+
+				<dependency>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-csv</artifactId>
+					<version>1.5</version>
+				</dependency>
+
+				<dependency>
+					<groupId>br.com.objectos</groupId>
+					<artifactId>way-io</artifactId>
+					<version>2.1.0</version>
+				</dependency>
+
+				<dependency>
+					<groupId>com.fasterxml.jackson.dataformat</groupId>
+					<artifactId>jackson-dataformat-csv</artifactId>
+					<version>2.9.1</version>
+				</dependency>
+				<dependency>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+					<version>2.9.1</version>
+				</dependency>
+
+				<dependency>
+					<groupId>net.sf.flatpack</groupId>
+					<artifactId>flatpack</artifactId>
+					<version>4.0.1</version>
+				</dependency>
+
+				<dependency>
+					<groupId>org.simpleflatmapper</groupId>
+					<artifactId>sfm-csv</artifactId>
+					<version>3.13.2</version>
+				</dependency>
+
+				<dependency>
+					<groupId>com.espertech</groupId>
+					<artifactId>esperio-csv</artifactId>
+					<version>6.1.0</version>
+				</dependency>
+
+			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-patch-plugin</artifactId>
+						<version>1.2</version>
+						<configuration>
+
+							<!-- patches required for API changes in newer libraries -->
+
+							<patches>
+								<patch>esperio-csv-6.x.patch</patch>
+								<patch>flatpack-4.x.patch</patch>
+							</patches>
+						</configuration>
+						<executions>
+							<execution>
+								<id>patch</id>
+								<goals>
+									<goal>apply</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+
+		</profile>
+
+	</profiles>
 </project>

--- a/src/main/java/com/univocity/articles/csvcomparison/CorrectnessComparison.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/CorrectnessComparison.java
@@ -16,13 +16,15 @@
 package com.univocity.articles.csvcomparison;
 
 import java.io.*;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.*;
 
 import com.univocity.articles.csvcomparison.parser.*;
 
 public class CorrectnessComparison {
 
-	private static File file = new File("src/main/resources/correctness.csv");
+	private static final String CORRECTNESS_FILE =  "correctness.csv";
 
 	private static String[][] expectedResult = new String[][] {
 		{ "Year", "Make", "Model", "Description", "Price" },
@@ -33,7 +35,7 @@ public class CorrectnessComparison {
 		{ null, null, "Venture \"Extended Edition\"", null, "4900.00" }
 	};
 
-	private static void assertHeadersAndValuesMatch(AbstractParser parser) throws Exception {
+	private static void assertHeadersAndValuesMatch(File file, AbstractParser parser) throws Exception {
 
 		List<String[]> parsedRows = parser.parseRows(file);
 
@@ -61,11 +63,26 @@ public class CorrectnessComparison {
 		}
 	}
 
-	public static void main(String... args) {
+	public static void main(final String... args) throws URISyntaxException {
+
+		final File input;
+		final URL inputUrl = CorrectnessComparison.class.getClassLoader().getResource(CORRECTNESS_FILE);
+		if(inputUrl != null) {
+			input = new File(inputUrl.toURI());
+		} else {
+			if(args.length > 0) {
+				input = new File(args[0], CORRECTNESS_FILE);
+				if(!input.exists()) {
+					throw new IllegalStateException("Could not find '" + CORRECTNESS_FILE + "' in classpath or in folder: " + args[0]);
+				}
+			} else {
+				throw new IllegalStateException("Could not find '" + CORRECTNESS_FILE + "' in classpath");
+			}
+		}
 
 		for (AbstractParser parser : Parsers.list()) {
 			try {
-				assertHeadersAndValuesMatch(parser);
+				assertHeadersAndValuesMatch(input, parser);
 			} catch (Throwable ex) {
 				System.err.println("Parser " + parser.getName() + " threw exception " + ex.getMessage());
 			}

--- a/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
@@ -22,9 +22,8 @@ import com.univocity.parsers.csv.*;
 public class HugeFileGenerator {
 
 	public static void generateHugeFile(File input, int timesToExpand, File hugeFile) throws Exception {
-		File output = new File("src/main/resources/worldcitiespop_huge.txt");
 
-		if (output.exists()) {
+		if (hugeFile.exists()) {
 			System.out.println("Huge file already generated.");
 			return;
 		}
@@ -34,7 +33,7 @@ public class HugeFileGenerator {
 		CsvWriterSettings settings = new CsvWriterSettings();
 		settings.setQuoteAllFields(true); //let's see how all parsers perform when the contents are enclosed within quotes.
 
-		CsvWriter writer = new CsvWriter(new OutputStreamWriter(new FileOutputStream(output), "ISO-8859-1"), settings);
+		CsvWriter writer = new CsvWriter(new OutputStreamWriter(new FileOutputStream(hugeFile), "ISO-8859-1"), settings);
 		long totalTime = 0L;
 		try {
 			Object[] row;

--- a/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
@@ -21,7 +21,7 @@ import com.univocity.parsers.csv.*;
 
 public class HugeFileGenerator {
 
-	public static void generateHugeFile(File input, int timesToExpand, File hugeFile) throws Exception {
+	public static void generateHugeFile(File input, String inputEncoding, int timesToExpand, File hugeFile) throws Exception {
 
 		if (hugeFile.exists()) {
 			System.out.println("Huge file already generated.");
@@ -33,14 +33,14 @@ public class HugeFileGenerator {
 		CsvWriterSettings settings = new CsvWriterSettings();
 		settings.setQuoteAllFields(true); //let's see how all parsers perform when the contents are enclosed within quotes.
 
-		CsvWriter writer = new CsvWriter(new OutputStreamWriter(new FileOutputStream(hugeFile), "ISO-8859-1"), settings);
+		CsvWriter writer = new CsvWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(hugeFile), inputEncoding)), settings);
 		long totalTime = 0L;
 		try {
 			Object[] row;
 			for (int i = 0; i < timesToExpand; i++) {
 				long start = System.currentTimeMillis();
 
-				parser.beginParsing(new InputStreamReader(new FileInputStream(input), "ISO-8859-1"));
+				parser.beginParsing(new BufferedReader(new InputStreamReader(new FileInputStream(input), inputEncoding)));
 				while ((row = parser.parseNext()) != null) {
 					writer.writeRow(row);
 				}

--- a/src/main/java/com/univocity/articles/csvcomparison/PerformanceComparison.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/PerformanceComparison.java
@@ -16,12 +16,16 @@
 package com.univocity.articles.csvcomparison;
 
 import java.io.*;
+import java.net.URL;
 import java.util.*;
 import java.util.Map.Entry;
 
 import com.univocity.articles.csvcomparison.parser.*;
 
 public class PerformanceComparison {
+
+	private static final String WORLDCITIES_FILE = "worldcitiespop.txt";
+	private static final String WORLDCITIES_HUGE_FILE = "worldcitiespop_huge.txt";
 
 	private final File file;
 
@@ -139,11 +143,35 @@ public class PerformanceComparison {
 	public static void main(String... args) throws Exception {
 		
 		int loops = 6;
-		File input = new File("src/main/resources/worldcitiespop.txt");
+
+		final File input;
+		final URL inputUrl = PerformanceComparison.class.getClassLoader().getResource(WORLDCITIES_FILE);
+		if(inputUrl != null) {
+			input = new File(inputUrl.toURI());
+		} else {
+			if(args.length > 0) {
+				input = new File(args[0], WORLDCITIES_FILE);
+				if(!input.exists()) {
+					throw new IllegalStateException("Could not find '" + WORLDCITIES_FILE + "' in classpath or in folder: " + args[0]);
+				}
+			} else {
+				throw new IllegalStateException("Could not find '" + WORLDCITIES_FILE + "' in classpath");
+			}
+		}
 	
 		new PerformanceComparison(input).execute(loops);
 
-		File hugeInput = new File("src/main/resources/worldcitiespop_huge.txt");
+		final File hugeInput;
+		final URL hugeInputUrl = PerformanceComparison.class.getClassLoader().getResource(WORLDCITIES_HUGE_FILE);
+		if(hugeInputUrl != null) {
+			hugeInput = new File(hugeInputUrl.toURI());
+		} else {
+			if(args.length > 0) {
+				hugeInput = new File(args[0], WORLDCITIES_HUGE_FILE);
+			} else {
+				throw new IllegalStateException("Could not find '" + WORLDCITIES_HUGE_FILE + "' in classpath or path not specified at arg[0]");
+			}
+		}
 		
 		
 		//executes only if the file has not been generated yet.

--- a/src/main/java/com/univocity/articles/csvcomparison/PerformanceComparison.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/PerformanceComparison.java
@@ -168,7 +168,7 @@ public class PerformanceComparison {
 					throw new IllegalStateException("Could not find '" + WORLDCITIES_FILE + "' in classpath or in folder: " + args[0]);
 				}
 			} else {
-				throw new IllegalStateException("Could not find '" + WORLDCITIES_FILE + "' in classpath");
+				throw new IllegalStateException("Could not find '" + WORLDCITIES_FILE + "' in classpath, or path not specified as arg[0]");
 			}
 		}
 	
@@ -182,7 +182,7 @@ public class PerformanceComparison {
 			if(args.length > 0) {
 				hugeInput = new File(args[0], WORLDCITIES_HUGE_FILE);
 			} else {
-				throw new IllegalStateException("Could not find '" + WORLDCITIES_HUGE_FILE + "' in classpath or path not specified at arg[0]");
+				throw new IllegalStateException("Could not find '" + WORLDCITIES_HUGE_FILE + "' in classpath, or path not specified as arg[0]");
 			}
 		}
 		

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/AbstractParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/AbstractParser.java
@@ -54,25 +54,9 @@ public abstract class AbstractParser {
 	public String getBlackhole(){
 		return String.valueOf(blackhole);
 	}
-	
-	protected Reader toReader(File input) {
-		try {
-			return new FileReader(input);
-		} catch (FileNotFoundException e) {
-			throw new IllegalStateException(e);
-		}
-	}
 
-	protected Charset getEncoding() {
-		return Charset.forName(getEncodingName());
-	}
+	public abstract void processRows(Reader reader) throws Exception;
 
-	protected String getEncodingName() {
-		return "ISO-8859-1";
-	}
-
-	public abstract void processRows(File input) throws Exception;
-
-	public abstract List<String[]> parseRows(File input) throws Exception;
+	public abstract List<String[]> parseRows(Reader reader) throws Exception;
 
 }

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/BeanIoParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/BeanIoParser.java
@@ -27,14 +27,14 @@ public class BeanIoParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CsvReader reader = new CsvReader(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CsvReader reader = new CsvReader(input);
 		
 		while (process(reader.read()));
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
 		CsvParserConfiguration cfg = new CsvParserConfiguration();
@@ -43,7 +43,7 @@ public class BeanIoParser extends AbstractParser {
 		cfg.setQuote('"');
 		cfg.setDelimiter(',');
 
-		CsvReader reader = new CsvReader(toReader(input), cfg);
+		CsvReader reader = new CsvReader(input, cfg);
 
 		String[] row;
 		while ((row = reader.read()) != null) {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/CSVeedParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/CSVeedParser.java
@@ -27,17 +27,17 @@ class CSVeedParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CsvClient<Row> parser = new CsvClientImpl<Row>(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CsvClient<Row> parser = new CsvClientImpl<Row>(input);
 		while (process(parser.readRow()));
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
 		Row row;
-		CsvClient<Row> parser = new CsvClientImpl<Row>(toReader(input));
+		CsvClient<Row> parser = new CsvClientImpl<Row>(input);
 		while ((row = parser.readRow()) != null) {
 			String[] data = new String[row.size()];
 			for (int i = 0; i < data.length; i++) {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/CommonsCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/CommonsCsvParser.java
@@ -27,18 +27,18 @@ class CommonsCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 		CSVFormat format = CSVFormat.RFC4180;
-		CSVParser parser = CSVParser.parse(input, getEncoding(), format);
+		CSVParser parser = new CSVParser(input, format);
 		for (CSVRecord record : parser) {
 			process(record);
 		}
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		CSVFormat format = CSVFormat.RFC4180;
-		CSVParser parser = CSVParser.parse(input, getEncoding(), format);
+		CSVParser parser = new CSVParser(input, format);
 
 		List<String[]> rows = new ArrayList<String[]>();
 

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/EsperioCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/EsperioCsvParser.java
@@ -28,7 +28,7 @@ class EsperioCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 
 		AdapterInputSource adapterInputSource = new AdapterInputSource(input);
 		CSVReader reader = new CSVReader(adapterInputSource);
@@ -40,7 +40,7 @@ class EsperioCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 		AdapterInputSource adapterInputSource = new AdapterInputSource(input);
 		CSVReader reader = new CSVReader(adapterInputSource);

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/FlatpackParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/FlatpackParser.java
@@ -27,17 +27,17 @@ class FlatpackParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 
-		Parser parser = DefaultParserFactory.getInstance().newDelimitedParser(toReader(input), ',', '\n');
+		Parser parser = DefaultParserFactory.getInstance().newDelimitedParser(input, ',', '\n');
 		DataSet dataset = parser.parse();
 		while (process(dataset.next()));
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
-		Parser parser = DefaultParserFactory.getInstance().newDelimitedParser(toReader(input), ',', '"');
+		Parser parser = DefaultParserFactory.getInstance().newDelimitedParser(input, ',', '"');
 
 		DataSet dataset = parser.parse();
 

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/GenJavaParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/GenJavaParser.java
@@ -27,16 +27,16 @@ class GenJavaParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CsvReader reader = new CsvReader(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CsvReader reader = new CsvReader(input);
 		while (process(reader.readLine()));
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
-		CsvReader reader = new CsvReader(toReader(input));
+		CsvReader reader = new CsvReader(input);
 		String[] row;
 		while ((row = reader.readLine()) != null) {
 			rows.add(row);

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/JCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/JCsvParser.java
@@ -28,17 +28,17 @@ class JCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 
-		CSVReader<String[]> reader = CSVReaderBuilder.newDefaultReader(toReader(input));
+		CSVReader<String[]> reader = CSVReaderBuilder.newDefaultReader(input);
 
 		while (process(reader.readNext()));
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
-		CSVReader<String[]> reader = CSVReaderBuilder.newDefaultReader(toReader(input));
+		CSVReader<String[]> reader = CSVReaderBuilder.newDefaultReader(input);
 		String[] row;
 
 		while ((row = reader.readNext()) != null) {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/JacksonParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/JacksonParser.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvParser;
 
-import java.io.File;
+import java.io.Reader;
 import java.util.*;
 
 public class JacksonParser extends AbstractParser {
@@ -15,7 +15,7 @@ public class JacksonParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(final File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 
 		CsvMapper csvMapper = new CsvMapper();
 		csvMapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
@@ -29,7 +29,7 @@ public class JacksonParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(final File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 
 		CsvMapper csvMapper = new CsvMapper();
 		csvMapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/JacksonParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/JacksonParser.java
@@ -20,7 +20,7 @@ public class JacksonParser extends AbstractParser {
 		CsvMapper csvMapper = new CsvMapper();
 		csvMapper.enable(CsvParser.Feature.WRAP_AS_ARRAY);
 
-		MappingIterator<String[]> iterator = csvMapper.reader(String[].class).readValues(input);
+		MappingIterator<String[]> iterator = csvMapper.readerFor(String[].class).readValues(input);
 
 		while (iterator.hasNext()) {
 			process(iterator.next());

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/JavaCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/JavaCsvParser.java
@@ -27,19 +27,19 @@ class JavaCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
+	public void processRows(final Reader input) throws Exception {
 
-		CsvReader reader = new CsvReader(toReader(input));
+		CsvReader reader = new CsvReader(input);
 		while (reader.readRecord()){
 			process(reader.getValues());
 		}
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
-		CsvReader reader = new CsvReader(toReader(input));
+		CsvReader reader = new CsvReader(input);
 		while (reader.readRecord()) {
 			rows.add(reader.getValues());
 		}

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/OpenCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/OpenCsvParser.java
@@ -27,8 +27,8 @@ class OpenCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CSVReader reader = new CSVReader(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CSVReader reader = new CSVReader(input);
 		try {
 			while (process(reader.readNext()));
 		} finally {
@@ -37,8 +37,8 @@ class OpenCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
-		CSVReader reader = new CSVReader(toReader(input));
+	public List<String[]> parseRows(final Reader input) throws Exception {
+		CSVReader reader = new CSVReader(input);
 		try {
 			return reader.readAll();
 		} finally {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/OsterMillerParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/OsterMillerParser.java
@@ -15,17 +15,14 @@ public class OsterMillerParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(final File input) throws Exception {
-
-		CSVParse csvParser = new ExcelCSVParser(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CSVParse csvParser = new ExcelCSVParser(input);
 		while (process(csvParser.getLine()));
 	}
 
 	@Override
-	public List<String[]> parseRows(final File input) throws Exception {
-
-		final CSVParse csvParser = new ExcelCSVParser(toReader(input));
-
+	public List<String[]> parseRows(final Reader input) throws Exception {
+		final CSVParse csvParser = new ExcelCSVParser(input);
 		return asList(csvParser.getAllValues());
 	}
 

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleCsvParser.java
@@ -27,8 +27,8 @@ class SimpleCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CsvReader reader = new CsvReader(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		CsvReader reader = new CsvReader(input);
 		try {
 			while (process(reader.readNext()));
 		} finally {
@@ -37,11 +37,11 @@ class SimpleCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
 		CsvParser parser = new CsvParserBuilder().escapeChar('"').multiLine(true).separator(',').build();
-		CsvReader reader = new CsvReader(toReader(input), parser);
+		CsvReader reader = new CsvReader(input, parser);
 		try {
 			List<String> row;
 			while ((row = reader.readNext()) != null) {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleFlatMapperParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleFlatMapperParser.java
@@ -1,7 +1,7 @@
 package com.univocity.articles.csvcomparison.parser;
 
 
-import java.io.File;
+import java.io.Reader;
 import java.util.*;
 
 import org.simpleflatmapper.csv.CsvParser;
@@ -13,17 +13,17 @@ public class SimpleFlatMapperParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(final File input) throws Exception {
-		final Iterator<String[]> it = CsvParser.iterator(toReader(input));
+	public void processRows(final Reader input) throws Exception {
+		final Iterator<String[]> it = CsvParser.iterator(input);
 		while(it.hasNext()) {
 			process(it.next());
 		}
 	}
 
 	@Override
-	public List<String[]> parseRows(final File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		final List<String[]> list = new ArrayList<String[]>();
-		final Iterator<String[]> it = CsvParser.iterator(toReader(input));
+		final Iterator<String[]> it = CsvParser.iterator(input);
 		while(it.hasNext()) {
 			list.add(it.next());
 		}

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleFlatMapperParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/SimpleFlatMapperParser.java
@@ -4,9 +4,7 @@ package com.univocity.articles.csvcomparison.parser;
 import java.io.File;
 import java.util.*;
 
-import org.sfm.csv.CsvParser;
-import org.sfm.utils.ListHandler;
-import org.sfm.utils.RowHandler;
+import org.simpleflatmapper.csv.CsvParser;
 
 public class SimpleFlatMapperParser extends AbstractParser {
 	protected SimpleFlatMapperParser() {
@@ -16,17 +14,19 @@ public class SimpleFlatMapperParser extends AbstractParser {
 
 	@Override
 	public void processRows(final File input) throws Exception {
-		CsvParser.readRows(toReader(input), new RowHandler<String[]>() {
-			@Override
-			public void handle(String[] t) throws Exception {
-				process(t);
-			}
-		});
+		final Iterator<String[]> it = CsvParser.iterator(toReader(input));
+		while(it.hasNext()) {
+			process(it.next());
+		}
 	}
 
 	@Override
 	public List<String[]> parseRows(final File input) throws Exception {
-		return CsvParser.readRows(toReader(input), new ListHandler<String[]>()).getList();
+		final List<String[]> list = new ArrayList<String[]>();
+		final Iterator<String[]> it = CsvParser.iterator(toReader(input));
+		while(it.hasNext()) {
+			list.add(it.next());
+		}
+		return list;
 	}
-
 }

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/SuperCsvParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/SuperCsvParser.java
@@ -28,8 +28,8 @@ class SuperCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		ICsvListReader listReader = new CsvListReader(toReader(input), CsvPreference.STANDARD_PREFERENCE);
+	public void processRows(final Reader input) throws Exception {
+		ICsvListReader listReader = new CsvListReader(input, CsvPreference.STANDARD_PREFERENCE);
 		try {
 			listReader.getHeader(true);
 			while (process(listReader.read()));
@@ -42,10 +42,10 @@ class SuperCsvParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
 
-		ICsvListReader listReader = new CsvListReader(toReader(input), CsvPreference.STANDARD_PREFERENCE);
+		ICsvListReader listReader = new CsvListReader(input, CsvPreference.STANDARD_PREFERENCE);
 		try {
 			List<String> row = null;
 			while ((row = listReader.read()) != null) {

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/UnivocityParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/UnivocityParser.java
@@ -29,7 +29,7 @@ class UnivocityParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) {
+	public void processRows(final Reader input) {
 		CsvParserSettings settings = new CsvParserSettings();
 		
 		//turning off features enabled by default
@@ -46,16 +46,16 @@ class UnivocityParser extends AbstractParser {
 		});
 		
 		CsvParser parser = new CsvParser(settings);
-		parser.parse(toReader(input));
+		parser.parse(input);
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) {
+	public List<String[]> parseRows(final Reader input) {
 
 		CsvParserSettings settings = new CsvParserSettings();
 		CsvParser parser = new CsvParser(settings);
 
-		return parser.parseAll(toReader(input));
+		return parser.parseAll(input);
 	}
 
 }

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/WayIoParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/WayIoParser.java
@@ -28,8 +28,8 @@ class WayIoParser extends AbstractParser {
 	}
 
 	@Override
-	public void processRows(File input) throws Exception {
-		CsvFile reader = CsvFile.parse(input);
+	public void processRows(final Reader input) throws Exception {
+		CsvFile reader = CsvFile.parseReader(input);
 
 		ParsedLines lines = reader.getLines();
 		for (Line line : lines) {
@@ -39,9 +39,9 @@ class WayIoParser extends AbstractParser {
 	}
 
 	@Override
-	public List<String[]> parseRows(File input) throws Exception {
+	public List<String[]> parseRows(final Reader input) throws Exception {
 		List<String[]> rows = new ArrayList<String[]>();
-		CsvFile reader = CsvFile.parse(input);
+		CsvFile reader = CsvFile.parseReader(input);
 
 		ParsedLines lines = reader.getLines();
 

--- a/src/main/patches/esperio-csv-6.x.patch
+++ b/src/main/patches/esperio-csv-6.x.patch
@@ -1,0 +1,10 @@
+--- com/univocity/articles/csvcomparison/parser/EsperioCsvParser.java
++++ com/univocity/articles/csvcomparison/parser/EsperioCsvParser.java
+@@ -18,7 +18,6 @@ package com.univocity.articles.csvcomparison.parser;
+ import java.io.*;
+ import java.util.*;
+ 
+-import com.espertech.esperio.*;
+ import com.espertech.esperio.csv.*;
+ 
+ class EsperioCsvParser extends AbstractParser {

--- a/src/main/patches/flatpack-4.x.patch
+++ b/src/main/patches/flatpack-4.x.patch
@@ -1,0 +1,33 @@
+--- com/univocity/articles/csvcomparison/parser/FlatpackParser.java
++++ com/univocity/articles/csvcomparison/parser/FlatpackParser.java
+@@ -17,6 +17,7 @@ package com.univocity.articles.csvcomparison.parser;
+ 
+ import java.io.*;
+ import java.util.*;
++import java.util.Optional;
+ 
+ import net.sf.flatpack.*;
+ 
+@@ -42,13 +43,16 @@ class FlatpackParser extends AbstractParser {
+ 		DataSet dataset = parser.parse();
+ 
+ 		while (dataset.next()) {
+-			Record record = dataset.getRecord();
+-			String[] row = new String[record.getColumns().length];
+-			int i = 0;
+-			for (String column : record.getColumns()) {
+-				row[i++] = record.getString(column);
++			final Optional<Record> maybeRecord = dataset.getRecord();
++			if(maybeRecord.isPresent()) {
++				final Record record = maybeRecord.get();
++				String[] row = new String[record.getColumns().length];
++				int i = 0;
++				for (String column : record.getColumns()) {
++					row[i++] = record.getString(column);
++				}
++				rows.add(row);
+ 			}
+-			rows.add(row);
+ 		}
+ 		return rows;
+ 	}


### PR DESCRIPTION
1. We update to the latest version of the CSV Parsers (per JDK version).
2. Maven profiles are used to ensure the correct version for each JDK version.
3. Parsers are now correctly configured for different file encodings.
4. The build and results are now reproducible using:

    ```bash
    $ git clone https://github.com/uniVocity/csv-parsers-comparison.git
    $ cd csv-parsers-comparison
    $ wget http://www.maxmind.com/download/worldcities/worldcitiespop.txt.gz
    $ gunzip worldcitiespop.txt.gz
    $ mvn clean package
    $ jar target/csv-parsers-comparison-1.0-uber.jar .
    ```

    NOTE: the `.` at the end of the last command, this tells Java the folder containing the `worldcitiespop.txt`. You can alternatively specify a path to any folder that contains a `worldcitiespop.txt` file.