### PR TITLE
Fix bugs in running test in windows (fixed issue #21)

### DIFF
--- a/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/HugeFileGenerator.java
@@ -28,10 +28,13 @@ public class HugeFileGenerator {
 			return;
 		}
 
-		CsvParser parser = new CsvParser(new CsvParserSettings());
+		CsvParserSettings readerSettings = new CsvParserSettings();
+		readerSettings.getFormat().setLineSeparator("\n");
+		CsvParser parser = new CsvParser(readerSettings);
 
 		CsvWriterSettings settings = new CsvWriterSettings();
 		settings.setQuoteAllFields(true); //let's see how all parsers perform when the contents are enclosed within quotes.
+    settings.getFormat().setLineSeparator("\n");
 
 		CsvWriter writer = new CsvWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(hugeFile), inputEncoding)), settings);
 		long totalTime = 0L;

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/UnivocityParser.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/UnivocityParser.java
@@ -31,7 +31,8 @@ class UnivocityParser extends AbstractParser {
 	@Override
 	public void processRows(final Reader input) {
 		CsvParserSettings settings = new CsvParserSettings();
-		
+		settings.getFormat().setLineSeparator("\n");
+
 		//turning off features enabled by default
 		settings.getFormat().setLineSeparator("\n");
 		settings.setIgnoreLeadingWhitespaces(false);


### PR DESCRIPTION
While running the test in windows env, we should explicity set the line
separator as '\n', otherwise it cannot find the end of line and cause
failure.
Please see issue #21