### PR TITLE
Update diergo easy csv streamable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This is the list of all parsers currently tested.
 | jackson-dataformat-csv       | 2.6.7/2.7.9/2.9.4 | [github.com/FasterXML/jackson-dataformat-csv](http://github.com/FasterXML/jackson-dataformat-csv)  |
 | OsterMiller Utils            |           1.07.00 | [ostermiller.org/utils/CSV.html](http://ostermiller.org/utils/CSV.html)                            |
 | SimpleFlatMapper CSV parser  |            3.15.9 | [github.com/arnaudroger/SimpleFlatMapper](https://github.com/arnaudroger/SimpleFlatMapper)         |
-| Diergo Easy CSV Streamable   |             3.1.0 | [github.com/aburmeis/decs](https://github.com/aburmeis/decs)                                       |
+| Diergo Easy CSV Streamable   |             3.1.1 | [github.com/aburmeis/decs](https://github.com/aburmeis/decs)                                       |
 | Product Collections          |             1.4.5 | [github.com/marklister/product-collections](https://github.com/marklister/product-collections)     |
 
 ## Statistics (updated 28th of February, 2018)

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
 				<dependency>
 					<groupId>diergo</groupId>
 					<artifactId>decs</artifactId>
-					<version>3.1.0-RELEASE</version>
+					<version>3.1.1</version>
 				</dependency>
 
 			</dependencies>

--- a/src/main/java/com/univocity/articles/csvcomparison/parser/ParsersRegistry.java
+++ b/src/main/java/com/univocity/articles/csvcomparison/parser/ParsersRegistry.java
@@ -38,7 +38,7 @@ public class ParsersRegistry {
         final String javaVersion = System.getProperty("java.version");
         System.out.println("Detected Java version: " + javaVersion);
 
-        if(javaVersion != null && javaVersion.startsWith("1.8.")) {
+        if(javaVersion != null && (javaVersion.startsWith("1.8.") || !javaVersion.startsWith("1."))) {
             System.out.println("Also enabling Java 8 only parsers!");
             parsers.addAll(getJava8OnlyParsers());
         }


### PR DESCRIPTION
* minor update of Diergo Easy CSV Streamable 
* run Java8 parsers also for JDK 9 and above (tested with 11)